### PR TITLE
Find meta refresh with optional content formatting

### DIFF
--- a/lib/unwind.rb
+++ b/lib/unwind.rb
@@ -101,7 +101,7 @@ module Unwind
     
     def meta_refresh?(response)
       if response.status == 200
-        body_match = response.body.match(/<meta http-equiv=\"refresh\" content=\"0; URL=(.*)\">/i)
+        body_match = response.body.match(/<meta http-equiv=\"refresh\" content=\"0;\s*url='?(.*[^'$])'?\">/i)
         Addressable::URI.parse(body_match[1]) if body_match
       end
     end

--- a/test/redirect_follower_test.rb
+++ b/test/redirect_follower_test.rb
@@ -121,6 +121,22 @@ describe Unwind::RedirectFollower do
     end
   end
 
+  it 'should handle a meta-refresh without spacing between time and url' do
+    body = "<meta http-equiv=\"refresh\" content=\"0;url=http://www.example.com/\">"
+    FakeWeb.register_uri :get, 'http://foo.com', status: 200, body: body
+    follower = Unwind::RedirectFollower.resolve('http://foo.com')
+    assert follower.redirected?
+    assert_equal "http://www.example.com/", follower.final_url
+  end
+
+  it 'should handle a meta-refresh with url wrapped in single quotes' do
+    body = "<meta http-equiv=\"refresh\" content=\"0;url='http://www.example.com/'\">"
+    FakeWeb.register_uri :get, 'http://foo.com', status: 200, body: body
+    follower = Unwind::RedirectFollower.resolve('http://foo.com')
+    assert follower.redirected?
+    assert_equal "http://www.example.com/", follower.final_url
+  end
+
   describe 'handling 404s' do
     it "should set not_found?" do
       FakeWeb.register_uri :get, 'http://nope.com', status: 404


### PR DESCRIPTION
The formatting of the content attribute of a meta refresh element is
loose. This change will find meta refresh tags whose content may have
spacing between the redirect time and the url as well as URLs wrapped in
single quotes