### PR TITLE
Handle invalid canonical links

### DIFF
--- a/lib/unwind.rb
+++ b/lib/unwind.rb
@@ -1,4 +1,5 @@
 require "unwind/version"
+require 'unwind/canonical_link'
 require 'addressable/uri'
 require 'nokogiri'
 require 'faraday'
@@ -16,10 +17,10 @@ module Unwind
     def initialize(original_url, limit=5)
      @original_url, @redirect_limit = original_url, limit
      @redirects = []
-     
+
     end
 
-    def redirected? 
+    def redirected?
       !(self.final_url == self.original_url)
     end
 
@@ -75,7 +76,7 @@ module Unwind
 
     def handle_final_response(current_url, response)
       current_url = current_url.dup.to_s
-      if response.status == 200 &&  canonical = canonical_link?(response)
+      if response.status == 200 && (canonical = canonical_link(response))
         @redirects << current_url
         @final_url = canonical.to_s
       else
@@ -98,7 +99,7 @@ module Unwind
         redirect_uri.relative? ? Addressable::URI.join(response.env[:url].to_s, response['location']) : redirect_uri
       end
     end
-    
+
     def meta_refresh?(response)
       if response.status == 200
         body_match = response.body.match(/<meta http-equiv=\"refresh\" content=\"0;\s*url='?(.*[^'$])'?\">/i)
@@ -106,17 +107,14 @@ module Unwind
       end
     end
 
-    def canonical_link?(response)
+    def canonical_link(response)
       doc = Nokogiri::HTML(response.body)
 
-      if canonical = doc.at('link[rel=canonical]')
-        href = Addressable::URI.parse(canonical["href"])
-        return unless href
-        return Addressable::URI.join(response.env[:url].to_s, href) if href.relative?
-        return href
+      if (raw_canonical = doc.at('link[rel=canonical]'))
+        Unwind::CanonicalLink.new(response.env[:url].to_s, raw_canonical["href"]).resolve
+      else
+        nil
       end
-
-      false
     end
 
     def apply_cookie(response, headers)
@@ -138,9 +136,9 @@ module Unwind
   #borrowed (stolen) from HTTParty with minor updates
   #to handle all cookies existing in a single string
   class CookieHash < Hash
-    
+
     CLIENT_COOKIES = %w{path expires domain path secure httponly}
-    
+
     def add_cookies(value)
       case value
       when Hash

--- a/lib/unwind.rb
+++ b/lib/unwind.rb
@@ -1,5 +1,5 @@
-require "unwind/version"
-require 'unwind/canonical_link'
+require_relative 'unwind/version'
+require_relative 'unwind/canonical_link'
 require 'addressable/uri'
 require 'nokogiri'
 require 'faraday'

--- a/lib/unwind/canonical_link.rb
+++ b/lib/unwind/canonical_link.rb
@@ -1,0 +1,35 @@
+class Unwind::CanonicalLink
+  def initialize(base_url, link)
+    @base_url = base_url
+    @link     = link
+  end
+
+  def resolve
+    uri = Addressable::URI.parse(@link)
+    return if uri.nil?
+
+    if uri.relative?
+      build_from_relative(uri)
+    else
+      uri
+    end
+  end
+
+  private
+
+  def build_from_relative(uri)
+    base_uri = Addressable::URI.parse(@base_url)
+
+    if invalid_relative_uri?(uri, base_uri.host)
+      path = uri.to_s.gsub(base_uri.host, '')
+    else
+      path = uri.to_s
+    end
+
+    Addressable::URI.join(base_uri, path)
+  end
+
+  def invalid_relative_uri?(uri, host)
+    uri.to_s.match(host)
+  end
+end

--- a/lib/unwind/canonical_link.rb
+++ b/lib/unwind/canonical_link.rb
@@ -1,35 +1,39 @@
-class Unwind::CanonicalLink
-  def initialize(base_url, link)
-    @base_url = base_url
-    @link     = link
-  end
+require 'addressable/uri'
 
-  def resolve
-    uri = Addressable::URI.parse(@link)
-    return if uri.nil?
-
-    if uri.relative?
-      build_from_relative(uri)
-    else
-      uri
-    end
-  end
-
-  private
-
-  def build_from_relative(uri)
-    base_uri = Addressable::URI.parse(@base_url)
-
-    if invalid_relative_uri?(uri, base_uri.host)
-      path = uri.to_s.gsub(base_uri.host, '')
-    else
-      path = uri.to_s
+module Unwind
+  class CanonicalLink
+    def initialize(base_url, link)
+      @base_url = base_url
+      @link     = link
     end
 
-    Addressable::URI.join(base_uri, path)
-  end
+    def resolve
+      uri = Addressable::URI.parse(@link)
+      return if uri.nil?
 
-  def invalid_relative_uri?(uri, host)
-    uri.to_s.match(host)
+      if uri.relative?
+        build_from_relative(uri)
+      else
+        uri
+      end
+    end
+
+    private
+
+    def build_from_relative(uri)
+      base_uri = Addressable::URI.parse(@base_url)
+
+      if invalid_relative_uri?(uri, base_uri.host)
+        path = uri.to_s.gsub(base_uri.host, '')
+      else
+        path = uri.to_s
+      end
+
+      Addressable::URI.join(base_uri, path)
+    end
+
+    def invalid_relative_uri?(uri, host)
+      uri.to_s.match(host)
+    end
   end
 end

--- a/test/canonical_link_test.rb
+++ b/test/canonical_link_test.rb
@@ -1,0 +1,37 @@
+require 'minitest/autorun'
+require './lib/unwind/canonical_link'
+
+describe Unwind::CanonicalLink do
+  describe ".resolve" do
+    let(:resolved_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=251' }
+
+    describe "when canonical link is relative and invalid" do
+      let(:base_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=2517400' }
+      let(:link) { 'oncology.jamanetwork.com/article.aspx?articleid=251' }
+      subject { Unwind::CanonicalLink.new(base_url, link) }
+
+      it "builds a valid url" do
+        assert_equal subject.resolve.to_s, resolved_url
+      end
+    end
+
+    describe "when canonical link is relative and valid" do
+      let(:base_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=2517400' }
+      let(:link) { '/article.aspx?articleid=251' }
+      subject { Unwind::CanonicalLink.new(base_url, link) }
+
+      it "builds a valid url" do
+        assert_equal subject.resolve.to_s, resolved_url
+      end
+    end
+
+    describe "when canonical link is absolute" do
+      let(:base_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=2517400' }
+      subject { Unwind::CanonicalLink.new(base_url, resolved_url) }
+
+      it "returns the link" do
+        assert_equal subject.resolve.to_s, resolved_url
+      end
+    end
+  end
+end

--- a/test/redirect_follower_test.rb
+++ b/test/redirect_follower_test.rb
@@ -9,82 +9,82 @@ VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = true
 end
 
-describe Unwind::RedirectFollower do 
+describe Unwind::RedirectFollower do
 
   # needs to be regenerated to properly test...need to stop that :(
-  it 'should handle url with cookie requirement' do 
-    VCR.use_cassette('with cookie') do 
+  it 'should handle url with cookie requirement' do
+    VCR.use_cassette('with cookie') do
       follower = Unwind::RedirectFollower.resolve('http://ow.ly/1hf37P')
-      assert_equal 200,  follower.response.status 
+      assert_equal 200,  follower.response.status
       assert follower.redirected?
     end
   end
 
-  it 'should resolve the url' do 
-    VCR.use_cassette('xZVND1') do 
+  it 'should resolve the url' do
+    VCR.use_cassette('xZVND1') do
       follower = Unwind::RedirectFollower.resolve('http://j.mp/xZVND1')
-      assert_equal 'http://ow.ly/i/s1O0', follower.final_url 
+      assert_equal 'http://ow.ly/i/s1O0', follower.final_url
       assert_equal 'http://j.mp/xZVND1', follower.original_url
       assert_equal 2, follower.redirects.count
       assert follower.redirected?
     end
   end
 
-  it 'should handle relative redirects' do 
-    VCR.use_cassette('relative stackoverflow') do 
+  it 'should handle relative redirects' do
+    VCR.use_cassette('relative stackoverflow') do
       follower = Unwind::RedirectFollower.resolve('http://stackoverflow.com/q/9277007/871617?stw=1')
       assert follower.redirected?
       assert_equal 'http://stackoverflow.com/questions/9277007/gitlabhq-w-denied-for-rails', follower.final_url
     end
   end
 
-  it 'should still handine relative redirects' do 
+  it 'should still handine relative redirects' do
     # http://bit.ly/A4H3a2
-    VCR.use_cassette('relative stackoverflow 2') do 
+    VCR.use_cassette('relative stackoverflow 2') do
       follower = Unwind::RedirectFollower.resolve('http://bit.ly/A4H3a2')
       assert follower.redirected?
     end
   end
 
-  it 'should handle redirects to pdfs' do 
-    VCR.use_cassette('pdf') do 
+  it 'should handle redirects to pdfs' do
+    VCR.use_cassette('pdf') do
       follower = Unwind::RedirectFollower.resolve('http://binged.it/wVSFs5')
-      assert follower.redirected? 
+      assert follower.redirected?
       assert_equal 'https://microsoft.promo.eprize.com/bingtwitter/public/fulfillment/rules.pdf', follower.final_url
     end
   end
 
-  it 'should handle the lame amazon spaces' do 
-    VCR.use_cassette('amazon') do 
+  it 'should handle the lame amazon spaces' do
+    VCR.use_cassette('amazon') do
       follower = Unwind::RedirectFollower.resolve('http://amzn.to/xrHQWS')
-      assert follower.redirected? 
+      assert follower.redirected?
     end
   end
 
   #http://amzn.to/xrHQWS
 
-  it 'should handle a https redirect' do 
-    VCR.use_cassette('ssl tpope') do 
+  it 'should handle a https redirect' do
+    VCR.use_cassette('ssl tpope') do
       follower = Unwind::RedirectFollower.resolve('http://github.com/tpope/vim-rails')
       assert follower.redirected?
       assert_equal 'https://github.com/tpope/vim-rails', follower.final_url
     end
   end
 
-  it 'should not be redirected' do 
-    VCR.use_cassette('no redirect') do 
+  it 'should not be redirected' do
+    VCR.use_cassette('no redirect') do
       follower  = Unwind::RedirectFollower.resolve('http://www.scottw.com')
       assert !follower.redirected?
-    end 
+    end
   end
 
-  it 'should set the final url as being the canonical url and treat it as s redirect' do 
-    VCR.use_cassette('canonical url', :preserve_exact_body_bytes => true) do 
+  it 'should set the final url as being the canonical url and treat it as s redirect' do
+    VCR.use_cassette('canonical url', :preserve_exact_body_bytes => true) do
       follower  = Unwind::RedirectFollower.resolve('http://www.scottw.com?test=abc')
       assert  follower.redirected?
       assert 'http://www.scottw.com', follower.final_url
       assert 'http://www.scottw?test=abc', follower.redirects[0]
-    end 
+    end
   end
 
   it 'should handle relative canonical urls' do
@@ -105,14 +105,14 @@ describe Unwind::RedirectFollower do
     end
   end
 
-  it 'should raise MissingRedirectLocation' do 
-    VCR.use_cassette('missing redirect') do 
+  it 'should raise MissingRedirectLocation' do
+    VCR.use_cassette('missing redirect') do
       follower = Unwind::RedirectFollower.new('http://tinyurl.com/6oqzkff')
       missing_redirect_location = lambda{follower.resolve}
       missing_redirect_location.must_raise Unwind::MissingRedirectLocation
     end
   end
-  
+
   it 'should handle a meta-refresh' do
     VCR.use_cassette('meta refresh') do
       follower = Unwind::RedirectFollower.resolve('http://www.nullrefer.com/?www.google.com')

--- a/vcr_cassettes/amazon.yml
+++ b/vcr_cassettes/amazon.yml
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Wed, 07 Mar 2012 17:19:47 GMT
 - request:
     method: get
-    uri: http://www.amazon.com/Microsoft-Introduction-Reference-Instructions-Shortcuts/dp/193622013X%3FSubscriptionId=05K53E00DQPJE1TBF0R2&tag=accessleedsco5-20&linkCode=xm2&camp=2025&creative=165953&creativeASIN=193622013X%2016UTC422February22132923656214th2Tuesday2012?utm_source=twitterfeed&utm_medium=twitter
+    uri: http://www.amazon.com/Microsoft-Introduction-Reference-Instructions-Shortcuts/dp/193622013X%3FSubscriptionId=05K53E00DQPJE1TBF0R2&tag=accessleedsco5-20&linkCode=xm2&camp=2025&creative=165953&creativeASIN=193622013X%2016UTC422February22132923656214th2Tuesday2012?utm_medium=twitter&utm_source=twitterfeed
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/118882667
Relative canonical links should not include the host but not everyone follows the rules.