### PR TITLE
Ensure cannonical links are stripped

### DIFF
--- a/lib/unwind/canonical_link.rb
+++ b/lib/unwind/canonical_link.rb
@@ -8,7 +8,7 @@ module Unwind
     end
 
     def resolve
-      uri = Addressable::URI.parse(@link)
+      uri = Addressable::URI.parse(@link.strip)
       return if uri.nil?
 
       if uri.relative?

--- a/test/redirect_follower_test.rb
+++ b/test/redirect_follower_test.rb
@@ -82,8 +82,8 @@ describe Unwind::RedirectFollower do
     VCR.use_cassette('canonical url', :preserve_exact_body_bytes => true) do
       follower  = Unwind::RedirectFollower.resolve('http://www.scottw.com?test=abc')
       assert  follower.redirected?
-      assert 'http://www.scottw.com', follower.final_url
-      assert 'http://www.scottw?test=abc', follower.redirects[0]
+      assert_equal 'http://www.scottw.com', follower.final_url
+      assert_equal 'http://www.scottw.com?test=abc', follower.redirects[0]
     end
   end
 
@@ -95,6 +95,16 @@ describe Unwind::RedirectFollower do
     follower = Unwind::RedirectFollower.resolve('http://foo.com/')
 
     assert follower.final_url, "http://foo.com/index.html"
+  end
+
+  it 'should handle surrounding whitespace in canonical url' do
+    FakeWeb.register_uri :get, 'http://foo.com/', status: 200, body: """
+      <body><link rel='canonical' href=' https://foo.com/home '></body>
+    """
+
+    follower  = Unwind::RedirectFollower.resolve('http://foo.com/')
+
+    assert_equal 'https://foo.com/home', follower.final_url
   end
 
   it 'should raise TooManyRedirects' do


### PR DESCRIPTION
For story https://www.pivotaltracker.com/story/show/128857829

Also see https://github.com/doximity/doximity/pull/15930

The `URI` parser in Doximity chokes on URIs that have leading or trailing spaces. This eliminates that in the rare instance they show up in a canonical link.

** QA Instructions **
Deploy https://github.com/doximity/doximity/pull/15930 to test this

Add a `doc_news_press_mention_url` with the url `https://connect.uclahealth.org/discussion/young-doctor-follows-in-his-fathers-footsteps/` and run `rake doc_news:press_mentions:process_imported`. No errors should be generated.