### PR TITLE
Add better error handling around canonical link parsing

### DIFF
--- a/lib/unwind/canonical_link.rb
+++ b/lib/unwind/canonical_link.rb
@@ -9,11 +9,6 @@ module Unwind
 
     def resolve
       begin
-        cleaned_link = @link.
-          strip.
-          gsub(/\p{C}/u, "").
-          sub(/^(%[A-Fa-f0-9]{2})+/, "").
-          strip
         uri = Addressable::URI.parse(cleaned_link)
         return if uri.nil?
 
@@ -51,6 +46,14 @@ module Unwind
 
     def missing_scheme?(uri, host)
       !uri.host.nil?
+    end
+
+    def cleaned_link
+      @cleaned_link ||= @link.
+        strip.
+        gsub(/\p{C}/u, "").
+        sub(/^(%[A-Fa-f0-9]{2})+/, "").
+        strip
     end
   end
 end

--- a/lib/unwind/canonical_link.rb
+++ b/lib/unwind/canonical_link.rb
@@ -49,6 +49,9 @@ module Unwind
     end
 
     def cleaned_link
+      # The following two regexes accomplish the following:
+      # 1. Removes invisible unicode characters in the url
+      # 2. Removes leading encoded characters (e.g. %01) before the url
       @cleaned_link ||= @link.
         strip.
         gsub(/\p{C}/u, "").

--- a/lib/unwind/canonical_link.rb
+++ b/lib/unwind/canonical_link.rb
@@ -8,13 +8,22 @@ module Unwind
     end
 
     def resolve
-      uri = Addressable::URI.parse(@link.strip)
-      return if uri.nil?
+      begin
+        cleaned_link = @link.
+          strip.
+          gsub(/\p{C}/u, "").
+          sub(/^(%[A-Fa-f0-9]{2})+/, "").
+          strip
+        uri = Addressable::URI.parse(cleaned_link)
+        return if uri.nil?
 
-      if uri.relative?
-        build_from_relative(uri)
-      else
-        uri
+        if uri.relative?
+          build_from_relative(uri)
+        else
+          uri
+        end
+      rescue Addressable::URI::InvalidURIError, NoMethodError
+        nil
       end
     end
 

--- a/test/canonical_link_test.rb
+++ b/test/canonical_link_test.rb
@@ -3,41 +3,78 @@ require './lib/unwind/canonical_link'
 
 describe Unwind::CanonicalLink do
   describe ".resolve" do
-    let(:resolved_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=251' }
     let(:base_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=2517400' }
+    let(:resolved_url) { 'http://oncology.jamanetwork.com/article.aspx?articleid=251' }
 
-    describe "when canonical link is relative and invalid" do
+    subject { Unwind::CanonicalLink.new(base_url, link).resolve }
+
+    describe 'when canonical link is relative and invalid' do
       let(:link) { 'oncology.jamanetwork.com/article.aspx?articleid=251' }
-      subject { Unwind::CanonicalLink.new(base_url, link) }
-
-      it "builds a valid url" do
-        assert_equal subject.resolve.to_s, resolved_url
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
       end
     end
 
     describe "when canonical link is relative and valid" do
       let(:link) { '/article.aspx?articleid=251' }
-      subject { Unwind::CanonicalLink.new(base_url, link) }
-
-      it "builds a valid url" do
-        assert_equal subject.resolve.to_s, resolved_url
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
       end
     end
 
     describe "when canonical link is absolute" do
-      subject { Unwind::CanonicalLink.new(base_url, resolved_url) }
-
-      it "returns the link" do
-        assert_equal subject.resolve.to_s, resolved_url
+      let(:link) { resolved_url }
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
       end
     end
 
     describe 'when canonical link is absolute without scheme' do
       let(:link) { '//oncology.jamanetwork.com/article.aspx?articleid=251' }
-      subject { Unwind::CanonicalLink.new(base_url, link) }
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
+      end
+    end
 
-      it 'builds a valid url using base_url scheme' do
-        assert_equal subject.resolve.to_s, resolved_url
+    describe 'when canonical link contains spaces' do
+      let(:link) { " #{resolved_url}"}
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
+      end
+    end
+
+    describe 'when canonical link contains leading invisible characters' do
+      let(:link) { "\x01#{resolved_url}" }
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
+      end
+    end
+
+    describe 'when canonical link contains leading symbols' do
+      let(:link) { "%01#{resolved_url}" }
+      it "resolves to the correct url" do
+        assert_equal(subject.to_s, resolved_url)
+      end
+    end
+
+    describe 'when canonical link is empty' do
+      let(:link) { "" }
+      it "resolves to the last known url" do
+        assert_equal(subject.to_s, base_url)
+      end
+    end
+
+    describe 'when link is nil' do
+      let(:link) { nil }
+      it "resolves to the correct url" do
+        assert_nil(subject)
+      end
+    end
+
+    describe 'when link is completely unreadable' do
+      let(:link) { ":::::"}
+      it "resolves to the correct url" do
+        assert_nil(subject)
       end
     end
   end


### PR DESCRIPTION
For story: https://www.pivotaltracker.com/story/show/128857829
Also see: https://github.com/doximity/doximity/pull/17054
And: https://github.com/doximity/doc-news-public/pull/73

Odd characters keep showing up in canonical link listing. This sets up error handling around three cases:
1. Leading escaped characters are removed (e.g. `"%01http://..."` becomes `"http://..."`)
2. Invisible characters are removed (e.g. `"\x01http://..."` becomes `"http://..."`)
3. Unparsable strings fall back to the url they were found on (e.g. `"::::"` returns `nil` which allows the base url to be returned)