### PR TITLE
Delegate cookie management to faraday-cookie_jar

### DIFF
--- a/unwind.gemspec
+++ b/unwind.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "vcr", "~> 2.0.0"
   s.add_development_dependency "fakeweb"
   s.add_runtime_dependency "faraday", '~> 0.9.0'
+  s.add_runtime_dependency "faraday-cookie_jar", '~> 0.0.6'
   s.add_runtime_dependency "nokogiri"
   s.add_runtime_dependency "addressable", "~> 2.3.6"
 end


### PR DESCRIPTION
Because it seems to be more robust that what we have and fixes an issue we're having with resolving URLs that relies heavily on cookies to work.