### PR TITLE
Fixed existing broken tests, switched from fakeweb to webmock.

### DIFF
--- a/unwind.gemspec
+++ b/unwind.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"
-  s.add_development_dependency "vcr", "~> 2.0.0"
-  s.add_development_dependency "fakeweb"
-  s.add_runtime_dependency "faraday", '~> 0.9.0'
+  s.add_development_dependency "vcr", "~> 4.0"
+  s.add_development_dependency "webmock", "~> 3.4"
+  s.add_runtime_dependency "faraday", '~> 0.15'
   s.add_runtime_dependency "faraday-cookie_jar", '~> 0.0.6'
   s.add_runtime_dependency "nokogiri"
   s.add_runtime_dependency "addressable", "~> 2.5"


### PR DESCRIPTION
Unwind also needs a new gem version published, but I wanted all of the specs to be passing before that happened, so I fixed the specs which had been failing.
Fakeweb is ludicrously outdated and unsupported, other dox projects had moved off it long ago.